### PR TITLE
Replace Safe Network by SAFE Network

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,9 +6,9 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: Safe Network Explained
+title: SAFE Network Explained
 description: > # this means to ignore newlines until "baseurl:"
-  The safe network can be difficult to understand. These explanations
+  The SAFE Network can be difficult to understand. These explanations
   make it easy.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://safe-network-explained.github.io" # the base hostname & protocol for your site

--- a/_posts/2016-05-05-safe-for-bitcoiners.markdown
+++ b/_posts/2016-05-05-safe-for-bitcoiners.markdown
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Safe Network explained using bitcoin terminology"
+title:  "SAFE Network explained using bitcoin terminology"
 author: "Ian Coleman"
 date:   2016-05-05 00:00:00 +0000
 updated: 2017-10-06 00:00:00 +0000
@@ -10,11 +10,11 @@ Read in [English](#), [中文](https://maxweng.github.io/safe-network-explained.
 
 If you already know how bitcoin works, it makes sense to build on that knowledge when trying to understand SAFE rather than start from scratch.
 
-Despite the safe and bitcoin networks having very similar goals and outcomes, the differences in the way they work are quite substantial. If any of the explanations below seem labored, it's because bitcoin concepts only extend so far into describing the safe network. The similarities will take us a fair way, but eventually there are limitations.
+Despite the safe and bitcoin networks having very similar goals and outcomes, the differences in the way they work are quite substantial. If any of the explanations below seem labored, it's because bitcoin concepts only extend so far into describing the SAFE Network. The similarities will take us a fair way, but eventually there are limitations.
 
-The following content is not meant for obtaining an overall understanding of the safe network, but should provide a very solid basis for further reading.
+The following content is not meant for obtaining an overall understanding of the SAFE Network, but should provide a very solid basis for further reading.
 
-The terms used as the headings for each section are like individual windows in a house, allowing various bitcoin-centric perspectives into the safe network.
+The terms used as the headings for each section are like individual windows in a house, allowing various bitcoin-centric perspectives into the SAFE Network.
 
 ## Table of contents
 
@@ -68,7 +68,7 @@ The terms used as the headings for each section are like individual windows in a
 
 The blockchain is the most important innovation of bitcoin. The purpose of the blockchain is to achieve consensus for the state of data in the bitcoin network.
 
-The safe network addresses the same problem as the blockchain, namely that of consensus, but does not use a blockchain. The major innovation introduced by the safe network to solve the consensus problem is called 'close group consensus'.
+The SAFE Network addresses the same problem as the blockchain, namely that of consensus, but does not use a blockchain. The major innovation introduced by the SAFE Network to solve the consensus problem is called 'close group consensus'.
 
 With bitcoin and blockchains, every node of the network has a full copy of all data on the network. As new data is added to the network, every node keeps a copy of that data.
 
@@ -76,9 +76,9 @@ Safe keeps only a few copies of each piece of data on the network. Each piece of
 
 There is some doubt about how large groups should be, is this secure, why not more, why not less? Rather than jump to deriving this number by proof, take a moment to consider what is being achieved by the consensus rules of both bitcoin and safe: data should not be vulnerable to being lost, corrupted, or incorrectly modified. If that group of nodes can be manipulated (hacked or bribed etc), the data they control would not be considered secure. This concern is addressed by the first part of the phrase, 'close' group consensus.
 
-Closeness is the algorithm which determines how the group governing each piece of data is formed. Members of this group are chosen by the network in a way that is very difficult to manipulate (the difficulty of doing this, like bitcoin, changes depending on the size of the network, becoming harder as the network grows). Rather than go into the details of the close group consesus algorithm here, I would instead recommend reading about xor distance as used by the safe network and follow the information trail from there.
+Closeness is the algorithm which determines how the group governing each piece of data is formed. Members of this group are chosen by the network in a way that is very difficult to manipulate (the difficulty of doing this, like bitcoin, changes depending on the size of the network, becoming harder as the network grows). Rather than go into the details of the close group consesus algorithm here, I would instead recommend reading about xor distance as used by the SAFE Network and follow the information trail from there.
 
-To directly compare the language for the security of the bitcoin vs safe network, bitcoin is secured by 'proof of work', safe is secured by 'close group consensus'.
+To directly compare the language for the security of the bitcoin vs SAFE Network, bitcoin is secured by 'proof of work', safe is secured by 'close group consensus'.
 
 For more reading about consensus using close groups rather than a blockchain, it's worth reading [Consensus Systems](https://blog.maidsafe.net/tag/consensus-systems/) on the maidsafe blog. It's also worth reading about [Disjoint Groups](https://github.com/maidsafe/rfcs/blob/master/text/0037-disjoint-groups/0037-disjoint-groups.md).
 
@@ -92,7 +92,7 @@ In the same way the blockchain was the key innovation that allowed the realizati
 
 One breakthrough of the blockchain is that it's easy to verify the data you have is the true blockchain and not a malicious person sending you invalid data. This is possible because of proof of work, which is easy to verify but difficult to create.
 
-How does safe ensure the data you receive is from the 'true' safe network and not from a malicious actor impersonating the network?
+How does safe ensure the data you receive is from the 'true' SAFE Network and not from a malicious actor impersonating the network?
 
 There are two main mechanisms that work together to replace proof of work and protect data integrity.
 
@@ -104,7 +104,7 @@ By encrypting data at the client and then chaining the consensus of integrity fo
 
 These properties of both the data and the network make it extremely difficult to corrupt part of the network, the same way proof of work makes it extremely difficult to modify part of the blockchain.
 
-Self-encryption and chained close group consensus is how the safe network retains integrity without using proof of work.
+Self-encryption and chained close group consensus is how the SAFE Network retains integrity without using proof of work.
 
 Read more about [self-encryption on the wiki](https://safenetwork.wiki/en/Security_-_Self_encryption).
 
@@ -116,7 +116,7 @@ Read more about chained close group consensus in [the vault repository](https://
 
 Bitcoin is often said to have solved the 'double spend problem', which is akin to saying bitcoin retains data atomicity, consistency, isolation and durability ([ACID](https://en.wikipedia.org/wiki/ACID)) even though it's a distributed, decentralized and trustless network. This is a huge deal both in computer science and in real world applications. The result of this is money that's spent _stays_ spent. Or in data-terms, when data is changed, it stays changed.
 
-Safe has a token similar to that of bitcoin, called safecoin. Where bitcoin _transaction_ data is _appended_ to the blockchain, safecoin _ownership_ data is _updated_ on the safe network. How does safe ensure that coins spent on the safe network are not susceptible to double spending, and how does this compare to bitcoin's implementation?
+Safe has a token similar to that of bitcoin, called safecoin. Where bitcoin _transaction_ data is _appended_ to the blockchain, safecoin _ownership_ data is _updated_ on the SAFE Network. How does safe ensure that coins spent on the SAFE Network are not susceptible to double spending, and how does this compare to bitcoin's implementation?
 
 Let's establish a common understanding of bitcoin and double-spends. When bitcoin is received, the confidence it will not be double-spent depends on how many confirmations the transaction has. Double spend in bitcoin _is possible_, it's just very difficult. Replace-by-fee made the window for double spending much larger and simpler to execute, and double-spending in bitcoin should be thought of as very high or low _probabilities of confidence_, not by absolute certainty.
 
@@ -124,13 +124,13 @@ This is one of the biggest advantages safe has over bitcoin - transactions are e
 
 On the bitcoin blockchain, bitcoins are grouped into outputs, and do not exist as discrete entities. For example, the reward for mining a block is currently 25 BTC, but this 25 BTC is represented in a single transaction. 25 coins, 1 piece of data.
 
-Quite differently, every safecoin is a discrete piece of data with its own location on the network (just like regular data on the safe network). 25 safecoins would be 25 different bits of data on the safe network.
+Quite differently, every safecoin is a discrete piece of data with its own location on the network (just like regular data on the SAFE Network). 25 safecoins would be 25 different bits of data on the SAFE Network.
 
 This fundamentally different way of representing tokens is how safecoins can be transferred so quickly and with such high confidence. The transfer mechanism of safecoin is quite different to that of bitcoin.
 
 A safecoin is a special package of data (called mutable data) which contains details of the current owner (among other things). To transfer ownership of that coin, the current owner must verify their ownership (similar to a signature in a bitcoin transaction). If they own the coin, they are allowed to change the data for the coin's current owner to the new owner. The 'current owner' of a safecoin is like the utxo of a bitcoin transaction. Safecoins ownership can be traced only to the current owner, whereas bitcoins ownership can be traced back to the initial generation, which may include hundreds or thousands of owners.
 
-Transferring safecoin is a single atomic data event on the safe network. Once completed, it stays that way until the new owner decides to change it. There is no way it can be reversed, unlike bitcoin which can have changes to the mempool or even orphaned blocks.
+Transferring safecoin is a single atomic data event on the SAFE Network. Once completed, it stays that way until the new owner decides to change it. There is no way it can be reversed, unlike bitcoin which can have changes to the mempool or even orphaned blocks.
 
 Compare the cost of completing a transaction. In bitcoin, the cost of a transaction is the size of the transaction relative to the entire block, multiplied by the cost of the proof of work to generate the block. In safecoin, the cost is the resources required to obtain consensus for the piece of data (a close group of nodes must reach consensus then store the change) multiplied by the number of coins being spent. Safecoin transactions are extremely efficient compared to bitcoin transactions because close group consensus is much cheaper and faster than generating a proof of work.
 
@@ -144,9 +144,9 @@ However, the actual transaction included in the blockchain depends on what the m
 
 This highlights an interesting property of bitcoin - the 'true' state of the network can only be determined from the blockchain, which may be quite old, in some cases over an hour. This poses a challenging problem for merchants wanting to accept immediate payment, such as from in-store customers.
 
-How does the safe network compare in terms of truth and handling 'race' situations? If a client announces a change to part of the network and a different change simultaneously to another part of the network, how does this resolve?
+How does the SAFE Network compare in terms of truth and handling 'race' situations? If a client announces a change to part of the network and a different change simultaneously to another part of the network, how does this resolve?
 
-When data is to be changed on the safe network, a quorum (ie subset) of the close group nodes must agree to the change. If the client simultaneously announces different data so two thirds of the nodes in the group receive one version but a third receive a different version, consensus will not be reached and the change will not be made.
+When data is to be changed on the SAFE Network, a quorum (ie subset) of the close group nodes must agree to the change. If the client simultaneously announces different data so two thirds of the nodes in the group receive one version but a third receive a different version, consensus will not be reached and the change will not be made.
 
 It's actually a bit more subtle than that, depending on whether the data is mutable or immutable, a put or a post; but those details begins to blur the concept so it's best to research that yourself.
 
@@ -161,15 +161,15 @@ There are some relevant articles on the blog -
 
 As indicated in the section on Transaction propagation, zero confirmation transactions in bitcoin cannot be fully trusted, and with replace-by-fee, cannot be trusted at all.
 
-In safe, the resolution of a transaction should be extremely fast, typically less than a second (the network isn't live so this has not yet been confirmed publicly). This difference is due to the way transactions are represented and stored on the safe network.
+In safe, the resolution of a transaction should be extremely fast, typically less than a second (the network isn't live so this has not yet been confirmed publicly). This difference is due to the way transactions are represented and stored on the SAFE Network.
 
 A bitcoin transaction is represented as an _addition_ of data to the blockchain. Since adding data requires a new block, this is both time consuming and expensive. During the time between a transaction announcement on the network and its acceptance into the blockchain, the receiver cannot be sure if the transaction will be confirmed by inclusion in a block, hence the term 'zero confirmation' transaction and the associated wariness.
 
 A safecoin transaction is represented as a _modification_ to an existing piece of data, namely by changing the details for the current owner of the coin. The change to the data is performed by the network in an atomic operation, subject to approval by close group consensus. Once the close group consensus is agreed, the change is made and is final.
 
-The safe network does not have a concept of zero confirmations (or confirmations at all) and transactions are final once committed to the network, which happens as soon as the close group nodes have reached consensus on the change (typically less than a second).
+The SAFE Network does not have a concept of zero confirmations (or confirmations at all) and transactions are final once committed to the network, which happens as soon as the close group nodes have reached consensus on the change (typically less than a second).
 
-To better understand how transactions are made on the safe network, a good place to start is the entire [mutable data](https://github.com/maidsafe/rfcs/blob/c63ff6636d0dc21d6939856cf3a32445c3855b8c/text/0047-mutable-data/0047-mutable-data.md) rfc.
+To better understand how transactions are made on the SAFE Network, a good place to start is the entire [mutable data](https://github.com/maidsafe/rfcs/blob/c63ff6636d0dc21d6939856cf3a32445c3855b8c/text/0047-mutable-data/0047-mutable-data.md) rfc.
 
 [Back to Table Of Contents](#zero-confirmations_toc)
 
@@ -197,7 +197,7 @@ The proof of resource algorithm is surprisingly simple and clever.
 * The result from each data holder node is collected and decrypted by the checking group and results of all holders are compared
 * If any holder node returns a different result, it is considered to be compromised and is deranked
 
-This should begin to illustrate how important the concept of close group consensus is in the safe network. It forms the basis for basically every single operation on the network.
+This should begin to illustrate how important the concept of close group consensus is in the SAFE Network. It forms the basis for basically every single operation on the network.
 
 The clever bit is the nodes doing the checking don't need to have the data in order to check it. They rely on the data having been initially stored in a specific way (ie consensus across a close group) which allows it to check on it again in the future without needing to have a copy of the data itself.
 
@@ -229,13 +229,13 @@ Since the network is coded to only recognize 2^32 possible safecoin names, there
 
 Bitcoin rewards miners with new coins for keeping the network secure. As time goes on, the reward decreases (an essential part of the economics and incentives of bitcoin). This raises questions about what happens to bitcoin mining and security once the mining reward stops? Is bitcoin viable long term? The answer lies in transaction fees, which provide additional subsidy to miners and continues their incentive to mine.
 
-How does this compare with the long term sustainability and security of the safe network?
+How does this compare with the long term sustainability and security of the SAFE Network?
 
 One of the interesting features of safe is called 'recycling' coins. Performing certain actions on the network requires the expenditure of coin to the network itself, like how a bitcoin transaction requires leaving some 'unspent' coins which go to the miners in the form of a fee.
 
 Recycling safecoin means as long as people are actively using the network there will always be some supply of coins for vaults to claim via proof of resource. Recycling is actually a convenience term for a cumbersome technical phrase: creating a delete request on a safecoin mutable data. If you want to know more about how recycling works, these are good terms to research.
 
-Recycling is sometimes said to affect the economics of the safe network, because it allows the same coin to be 'minted' multiple times. Some people say this makes safecoin inflationary, but since there can never be more than 4.3B coins this isn't really true. It's like saying bitcoin is inflationary because the miners continue to receive coin from fees - in both bitcoin and the safe network the coins all come from the same limited resource pool, which makes both coins deflationary.
+Recycling is sometimes said to affect the economics of the SAFE Network, because it allows the same coin to be 'minted' multiple times. Some people say this makes safecoin inflationary, but since there can never be more than 4.3B coins this isn't really true. It's like saying bitcoin is inflationary because the miners continue to receive coin from fees - in both bitcoin and the SAFE Network the coins all come from the same limited resource pool, which makes both coins deflationary.
 
 [Back to Table Of Contents](#transaction-fees-and-long-term-sustainability_toc)
 
@@ -243,11 +243,11 @@ Recycling is sometimes said to affect the economics of the safe network, because
 
 An amazing property of the bitcoin network is how it automatically adjusts the difficulty of mining to ensure blocks are consistently ten minutes apart, even if the network grows or shrinks considerably. This ensures the rate of newly generated coins is kept fairly consistent with the planned schedule.
 
-What happens as the safe network grows and more resources join? How does this affect the generation of new coins and the incentives for new users joining the network?
+What happens as the SAFE Network grows and more resources join? How does this affect the generation of new coins and the incentives for new users joining the network?
 
 When a user completes a proof of resource they're entitled to create a new coin. The network generates a 32 bit 'name' for the newly generated coin. The network then checks if the coin for that name already has an owner. If it does, the mining attempt (or to use the safe term, farm attempt) is unsuccessful. If there's no user for the coin, it's created and assigned to the user who earned it.
 
-There's a similarity between undertaking proof of resource on the safe network and undertaking a proof of work when mining bitcoin. Most proof of work yields a result above the target, and no coins will issued for that particular proof of work.
+There's a similarity between undertaking proof of resource on the SAFE Network and undertaking a proof of work when mining bitcoin. Most proof of work yields a result above the target, and no coins will issued for that particular proof of work.
 
 The same idea applies to proof of resource. A proof of resource is simply a chance to earn a coin, not a guarantee. The proof must be converted to a coin by a mechanism called the farm rate.
 
@@ -269,7 +269,7 @@ Are there similar situations that will arise in safe which may undermine the ori
 
 There may be. Since there are only 4.3B coins available, it could become very difficult to claim a coin as an individual. This may lead to pooled farming, but it's hard to know for sure.
 
-I think speculation about the pitfalls of the safe network is important, but am unable to provide much insight on this myself. If you have ideas about it, please add a comment on the discussion at forum by clicking the link at the very bottom of all this. It's certainly an interesting topic, but one that's hard to provide concrete knowledge about.
+I think speculation about the pitfalls of the SAFE Network is important, but am unable to provide much insight on this myself. If you have ideas about it, please add a comment on the discussion at forum by clicking the link at the very bottom of all this. It's certainly an interesting topic, but one that's hard to provide concrete knowledge about.
 
 Vitalik Buterin from the ethereum project provided an interesting discussion about the [potential pitfalls](https://safenetforum.org/t/vitalik-buterin-on-maidsafes-consensus-mechanism/3542) that close group consensus may face.
 
@@ -279,15 +279,15 @@ Vitalik Buterin from the ethereum project provided an interesting discussion abo
 
 Bitcoin began with a 'one computer one vote' democratic ideal, however is now mired in controversy over miner centralization.
 
-Is the safe network likely to face similar issues of farmer centralization and industry-grade growth problems, and what might be the impact of such a situation?
+Is the SAFE Network likely to face similar issues of farmer centralization and industry-grade growth problems, and what might be the impact of such a situation?
 
 Firstly, this is a speculative section. Nobody can predict the future, although we can make fair guesses.
 
-It's extremely likely that if the safe network is successful it will have enterprise-level involvement. This will probably make the small-time farmers using their home pc and internet connection uncompetitive. Whether being 'uncompetitive' will prevent small users participating in farming is yet to be seen; after all, there are still plenty of 'irrational' bitcoiners running full nodes with little or no economic incentive.
+It's extremely likely that if the SAFE Network is successful it will have enterprise-level involvement. This will probably make the small-time farmers using their home pc and internet connection uncompetitive. Whether being 'uncompetitive' will prevent small users participating in farming is yet to be seen; after all, there are still plenty of 'irrational' bitcoiners running full nodes with little or no economic incentive.
 
-If the safe network becomes primarily centralized to a small number of giant data centers, it would have some pros and some cons.
+If the SAFE Network becomes primarily centralized to a small number of giant data centers, it would have some pros and some cons.
 
-Imagine a large-scale blackout across a nation. This could have extreme impact on the safe network, and possibly induce churn events that cannot be resolved. This is true of the network even without centralized farming, but would be especially prominent as farming becomes more centralized. This situation is a lot like the type of runaway bitcoin might face if verification of blocks takes longer than ten minutes, leading to a situation where it's impossible to catch up to the head of the blockchain.
+Imagine a large-scale blackout across a nation. This could have extreme impact on the SAFE Network, and possibly induce churn events that cannot be resolved. This is true of the network even without centralized farming, but would be especially prominent as farming becomes more centralized. This situation is a lot like the type of runaway bitcoin might face if verification of blocks takes longer than ten minutes, leading to a situation where it's impossible to catch up to the head of the blockchain.
 
 On a related tangent, [data chains](https://metaquestions.me/2016/07/20/data-chains-what-why-how/) will allow the network to be restored in the event of catastrophic failure, so data will not be lost.
 
@@ -311,9 +311,9 @@ The ability to form these different kinds of centralization depend on several fa
 * divergence between specialized and consumer 'resources', ie bandwidth, storage, computation etc and how this affects behavior
 * organizational and governance decisions, which depend on feedback of many types
 
-The safe network has balanced these considerations differently to blockchains (both proof-of-work and proof-of-stake), mainly due to the underlying structure of the network.
+The SAFE Network has balanced these considerations differently to blockchains (both proof-of-work and proof-of-stake), mainly due to the underlying structure of the network.
 
-It's worth reading the discussion on the safe network forum titled '[How is Farming Centralization Disincentivized](https://safenetforum.org/t/how-is-farming-centralization-disincentivized/6639)' to further understand decentralization on the safe network.
+It's worth reading the discussion on the SAFE Network forum titled '[How is Farming Centralization Disincentivized](https://safenetforum.org/t/how-is-farming-centralization-disincentivized/6639)' to further understand decentralization on the SAFE Network.
 
 Maybe your imagination can shed some additional light. If you can think of an interesting mode of centralization, please share it in the discussion using the link at the bottom of all this.
 
@@ -325,7 +325,7 @@ Bitcoin shot to fame when it was reported as 'used for buying drugs online' - a 
 
 At the same time, the transparency offered by the blockchain is one of its greatest assets.
 
-How private is the safe network?
+How private is the SAFE Network?
 
 This is best explained using the idea of a privacy continuum.
 
@@ -333,9 +333,9 @@ Bitcoin is by default a public system, with opt-in privacy. The user picks the d
 
 Safe is by default a private system, with opt-in transparency.
 
-By default, data on the safe network is encrypted, fragmented, and anonymized. This is because of the built in properties of self-encryption and routing.
+By default, data on the SAFE Network is encrypted, fragmented, and anonymized. This is because of the built in properties of self-encryption and routing.
 
-The privacy model of the safe network is nicely explained in the maidsafe blog post
+The privacy model of the SAFE Network is nicely explained in the maidsafe blog post
 [opting into transparency](https://blog.maidsafe.net/2014/08/23/opting-into-transparency/).
 
 However, this model of privacy raises some questions.
@@ -344,15 +344,15 @@ How do we know how many safecoins have currently been farmed?
 
 How do we progressively make our data more transparent and what degrees of control do we have?
 
-What is the permissions model for data on the safe network?
+What is the permissions model for data on the SAFE Network?
 
 How is permission allocated and revoked?
 
 How does a team of people work collaboratively on data?
 
-These are questions that require further research and are not explained here. Much of this will be supplied as an overlay on the safe network, rather than natively in the data layer itself.
+These are questions that require further research and are not explained here. Much of this will be supplied as an overlay on the SAFE Network, rather than natively in the data layer itself.
 
-This seems like a robust approach to developing the safe network, keeping the base level as simple as possible with sensible defaults, allowing additional uses to be built on a solid foundation.
+This seems like a robust approach to developing the SAFE Network, keeping the base level as simple as possible with sensible defaults, allowing additional uses to be built on a solid foundation.
 
 We see with bitcoin that having a strong foundation is essential to adding functionality via overlays - think of the lightning network, sidechains, multisig, HD wallets, segregated witness, the app ecosystem such as mixers and open bazaar; all made possible by initially creating bitcoin with a strong simple foundation.
 
@@ -368,15 +368,15 @@ Another classic terminology confusion is the use of Bitcoin vs bitcoin, or BTC v
 
 What's important is that terminology is specific for a reason. To effectively understand bitcoin requires a solid understanding of the lingo as well as the technical details.
 
-What similar strange quirks of nomenclature can be found in the safe network?
+What similar strange quirks of nomenclature can be found in the SAFE Network?
 
-* maidsafe vs safe network vs safecoin vs maidsafecoin
+* maidsafe vs SAFE Network vs safecoin vs maidsafecoin
 
     * Maidsafe: seemingly a catch-all phrase. The proper use is to refer to the organization overseeing the development of the network. But it's often used as a name for the network itself, the coin for the network; this has become a very confusing term which has been used in many different ways. The most correct use of this term is to refer to the for-profit organization that oversees the development of the network, including design, source code, marketing etc. The closely-related Maidsafe Foundation is the not-for-profit organization that [holds patents](http://cointelegraph.com/news/clearing-the-air-over-maidsafes-patent-request-an-interview-with-coo-nick-lambert) and fosters education and innovation. Maidsafe is an acronym for massive array of internet disks, secure access for everyone.
 
-    * safe network: the network that manages and stores data. Analogous to Bitcoin with a capital B. The safe network is not currently live but is undergoing testing and continued development before launch.
+    * SAFE Network: the network that manages and stores data. Analogous to Bitcoin with a capital B. The SAFE Network is not currently live but is undergoing testing and continued development before launch.
 
-    * safecoin: the token of exchange on the safe network. Analogous to bitcoin with a lowercase b. Not currently available since this feature has not yet been coded.
+    * safecoin: the token of exchange on the SAFE Network. Analogous to bitcoin with a lowercase b. Not currently available since this feature has not yet been coded.
 
     * maidsafecoin: the token issued as a presale to raise funds for the company to continue their work. Issued on the mastercoin protocol, it currently trades on exchanges and will be redeemable for safecoin once the network goes live and safecoin is available.
 
@@ -394,7 +394,7 @@ Network rate is the rate at which the network releases new coins.
 
 PmidManager vs MpidManager is a bit of esoteric naming, among many others. Go on, get yourself confused reading the [safe vault conventions](https://github.com/maidsafe/safe_vault/blob/bae659e579a56e145159805ce87770174f2d678b/docs/conventions.md)
 
-There are surely others but these are some of the main ones. My main tip for novices is to make sure the use of 'maidsafe' and 'safe network' are clear and consistent.
+There are surely others but these are some of the main ones. My main tip for novices is to make sure the use of 'maidsafe' and 'SAFE Network' are clear and consistent.
 
 Check out [the glossary](https://safenetwork.wiki/en/Glossary) on the wiki for more clarity.
 
@@ -404,15 +404,15 @@ Check out [the glossary](https://safenetwork.wiki/en/Glossary) on the wiki for m
 
 Bitcoin has a unique governance model, initially dominated by individuals such as Satoshi Nakamoto and Gavin Andresen, gradually giving way to a group of developers known as 'bitcoin core developers'. Other groups have come and gone with varying degrees of controversy, such as 'Bitcoin XT', 'Blockstream', and 'Bitcoin Classic'.
 
-How does this compare with the governance of safe network?
+How does this compare with the governance of SAFE Network?
 
-The SAFE network has a single implementation, unlike bitcoin which has several implementations. The SAFE Network is being developed and implemented by MaidSafe.net, a Scottish for profit company. The company has been set up with a Scottish charity, the MaidSafe Foundation, as its largest shareholder ensuring that dividends will be used to meet the Foundations charitable objectives, which are to support education and foster innovation.
+The SAFE Network has a single implementation, unlike bitcoin which has several implementations. The SAFE Network is being developed and implemented by MaidSafe.net, a Scottish for profit company. The company has been set up with a Scottish charity, the MaidSafe Foundation, as its largest shareholder ensuring that dividends will be used to meet the Foundations charitable objectives, which are to support education and foster innovation.
 
 The project is open source and accepts contributions from the community if they fit or improve the design.
 
 No alternative or competing implementation exist, however there is a desire in the future to have this happen.
 
-There are libraries to access the safe network written in various languages
+There are libraries to access the SAFE Network written in various languages
 
 [Go client library](https://github.com/cretz/go-safeclient/) and [discussion](https://safenetforum.org/t/ann-safe-cli-go-library-and-integration-tests-alpha-release/7957)
 
@@ -430,7 +430,7 @@ Safe 'core' is written in rust.
 
 Bitcoin was the first cryptocurrency, but it spawned hundreds of alternatives, such as litecoin and dogecoin, and hundreds of competitors, such as ripple and ethereum.
 
-Is safe an altcoin, a competitor, a complement? What is the competitive relation of the safe network to the bitcoin network?
+Is safe an altcoin, a competitor, a complement? What is the competitive relation of the SAFE Network to the bitcoin network?
 
 Safe is not an altcoin in the sense that altcoins are usually based on a blockchain and have a very similar fundamental mode of operation to bitcoin, with innovative tweaks and features added.
 
@@ -438,7 +438,7 @@ Safe is perhaps a competitor, depending how the relation is framed. Bitcoin is s
 
 The relationship and classification of safe relative to bitcoin depends on the perspective of each individual. Personally, in my heart I consider it a competitor first, with the possibility that it may replace bitcoin. But in my head I accept safe will more realistically be a 'complement' to bitcoin, operating side by side and filling a different-yet-similar purpose.
 
-Another consideration here is that safecoin is simply a 'specific type of mutable data on the safe network'. Other generic types of mutable data can (and will) be created on the safe network, which could be competing with or complementing safecoin. It may be that safecoin is not the dominant currency on the safe network, it all depends on adoption from users. One thing in safecoins favor is it will be the only currency that can be used to put data on the network, giving it a strong advantage over other mutable-data-as-currency.
+Another consideration here is that safecoin is simply a 'specific type of mutable data on the SAFE Network'. Other generic types of mutable data can (and will) be created on the SAFE Network, which could be competing with or complementing safecoin. It may be that safecoin is not the dominant currency on the SAFE Network, it all depends on adoption from users. One thing in safecoins favor is it will be the only currency that can be used to put data on the network, giving it a strong advantage over other mutable-data-as-currency.
 
 [Back to Table Of Contents](#altcoin_toc)
 
@@ -470,13 +470,13 @@ Is safecoin premined?
 
 Safecoin is premined. 10% of safecoin has been issued.
 
-You may wonder how this can possibly be, considering safecoin and the safe network do not yet exist!
+You may wonder how this can possibly be, considering safecoin and the SAFE Network do not yet exist!
 
 The way it was arranged was by issuing an intermediate token on the mastercoin network called maidsafecoin. This coin is traded on exchanges and has a value that fluctuates, just like other coins.
 
-When the safe network and safecoin is launched, maidsafecoin can be exchanged 1:1 for safecoin. The exact mechanism for this is not clear, but will probably be through a burn mechanism. The wiki has some [more information](https://safenetwork.wiki/en/FAQ#How_will_MaidSafeCoin_be_converted_to_safecoin_.3F) about how this may happen.
+When the SAFE Network and safecoin is launched, maidsafecoin can be exchanged 1:1 for safecoin. The exact mechanism for this is not clear, but will probably be through a burn mechanism. The wiki has some [more information](https://safenetwork.wiki/en/FAQ#How_will_MaidSafeCoin_be_converted_to_safecoin_.3F) about how this may happen.
 
-There was a lot of controversy over the initial sale of maidsafecoin. If the controversy of the presale is important to you it's best to research yourself, but I'm leaving it alone here. Perhaps the judgment of the people who organized it should be questioned, which may flow on to their technical judgment in creating the safe network; only you can be the judge.
+There was a lot of controversy over the initial sale of maidsafecoin. If the controversy of the presale is important to you it's best to research yourself, but I'm leaving it alone here. Perhaps the judgment of the people who organized it should be questioned, which may flow on to their technical judgment in creating the SAFE Network; only you can be the judge.
 
 [Back to Table Of Contents](#premine_toc)
 
@@ -484,15 +484,15 @@ There was a lot of controversy over the initial sale of maidsafecoin. If the con
 
 Bitcoin is the third major use of the word fork, after cutlery-based usage and usage in git. Forking is considered extremely undesirable and difficult to manage. Forks have happened on the bitcoin network, but they're rare and usually well-managed.
 
-Can the safe network fork? How does the safe network remain a single homogeneous whole?
+Can the SAFE Network fork? How does the SAFE Network remain a single homogeneous whole?
 
-This terminology is one of the harder ones to compare across the bitcoin and safe networks.
+This terminology is one of the harder ones to compare across the bitcoin and SAFE Networks.
 
 Let's start by framing 'forking' as 'breaking the network into two or more discretely different parts'.
 
 In this case, we must consider, how would safe become two different networks?
 
-It doesn't happen like bitcoin, which has a common root but a divergent head, since there is no 'root' or 'head' in the safe network.
+It doesn't happen like bitcoin, which has a common root but a divergent head, since there is no 'root' or 'head' in the SAFE Network.
 
 A 'fork' in safe would look like a corrupt portion of the network. Can this corrupt portion be detected and fixed? Will it remain stable and static as a corrupt portion forever? Will the corruption grow to affect the rest of the network?
 
@@ -500,7 +500,7 @@ Rather than labor the comparison, I think it's better to focus on the techniques
 
 Safe uses redundancy when storing data. Read about how it works in the [immutable data naming](https://github.com/maidsafe/rfcs/blob/1cd4ed22709fed673f5ce51c1d861d879abd7aec/text/0013-immutable-data-naming/0013-immutable-data-naming.md) rfc
 
-Safe uses a quorum of a supermajority of nodes in the close group to ensure data remains consistent and changes are valid. There's [an informative post](https://blog.maidsafe.net/2015/01/29/consensus-without-a-blockchain/) on the maidsafe blog about the consensus mechanism. The idea of close group consensus is so important to the operation of the safe network that it's worth reading about in detail.
+Safe uses a quorum of a supermajority of nodes in the close group to ensure data remains consistent and changes are valid. There's [an informative post](https://blog.maidsafe.net/2015/01/29/consensus-without-a-blockchain/) on the maidsafe blog about the consensus mechanism. The idea of close group consensus is so important to the operation of the SAFE Network that it's worth reading about in detail.
 
 [Back to Table Of Contents](#forking_toc)
 
@@ -508,19 +508,19 @@ Safe uses a quorum of a supermajority of nodes in the close group to ensure data
 
 Bitcoin implemented a change early on to restrict spam on the network. This is the now-infamous blocksize limit of 1MB.
 
-This introduces two important considerations. How does the safe network manage spam? How does the safe network implement changes when a bottleneck arises?
+This introduces two important considerations. How does the SAFE Network manage spam? How does the SAFE Network implement changes when a bottleneck arises?
 
-Spam is managed by charging safecoin to add data to the network. In the same way that 'no transaction is spam' on the bitcoin network, 'no data is spam' on the safe network. If it's valuable enough for the user to spend money to make it happen, it's not spam.
+Spam is managed by charging safecoin to add data to the network. In the same way that 'no transaction is spam' on the bitcoin network, 'no data is spam' on the SAFE Network. If it's valuable enough for the user to spend money to make it happen, it's not spam.
 
 In bitcoin, floating transaction fees has been a controversial mechanism, with some claiming it makes bitcoin unusable because it leads to higher transaction fees... I don't need to go into the details of this complex and often vitriolic topic here.
 
-There is every chance the same thing will happen with the safe network. Until we see how the balance between resource availability and resource consumption works, we can't know for certain - just like we didn't know for certain what would happen when the bitcoin network became congested and the blocksize issue became significant. It's not a purely technical or economic problem. People respond in different ways, even though the behavior of the network itself is predetermined.
+There is every chance the same thing will happen with the SAFE Network. Until we see how the balance between resource availability and resource consumption works, we can't know for certain - just like we didn't know for certain what would happen when the bitcoin network became congested and the blocksize issue became significant. It's not a purely technical or economic problem. People respond in different ways, even though the behavior of the network itself is predetermined.
 
-From a technical perspective, the safe network will adjust itself in a similar way the bitcoin network does, adjusting incentives in the form of money supply rate and the cost to perform operations on the network.
+From a technical perspective, the SAFE Network will adjust itself in a similar way the bitcoin network does, adjusting incentives in the form of money supply rate and the cost to perform operations on the network.
 
-The second issue is how are changes implemented? Bitcoin has faced challenges implementing changes because if the rules of the network are to be changed, there must be consensus. The safe network will face similar challenges of governence and consensus among developers if the network grows as large as the bitcoin network (large in terms of developers and community members, not in terms of node count or data throughput).
+The second issue is how are changes implemented? Bitcoin has faced challenges implementing changes because if the rules of the network are to be changed, there must be consensus. The SAFE Network will face similar challenges of governence and consensus among developers if the network grows as large as the bitcoin network (large in terms of developers and community members, not in terms of node count or data throughput).
 
-One thing going for the safe network at this point is the clear governance model by having the code developed by a not-for-profit organization. This is a double edged sword - on one hand it makes it clear where the decision comes from and the reasoning behind it, but on the other hand it promotes appeal-to-authority and may leave smaller voices with sound technical reasoning ignored. This is one of those topics that has no 'best' answer, and the main point is to at least be aware of how it is and how it isn't.
+One thing going for the SAFE Network at this point is the clear governance model by having the code developed by a not-for-profit organization. This is a double edged sword - on one hand it makes it clear where the decision comes from and the reasoning behind it, but on the other hand it promotes appeal-to-authority and may leave smaller voices with sound technical reasoning ignored. This is one of those topics that has no 'best' answer, and the main point is to at least be aware of how it is and how it isn't.
 
 [Back to Table Of Contents](#blocksize_toc)
 
@@ -528,17 +528,17 @@ One thing going for the safe network at this point is the clear governance model
 
 Related to blocksize, the issue of scaling is a hot topic in the world of bitcoin.
 
-How does the safe network scale, and what are the likely bottlenecks of the network?
+How does the SAFE Network scale, and what are the likely bottlenecks of the network?
 
-The most obvious one, which was a complaint of similar systems such as freenet, will be bandwidth and latency. If the network cannot achieve efficiency in delivering and storing data, it will not be popular. There are strict physical limits to the speed at which a global network can operate, light simply won't travel through fibre optic any faster. Safe will need to overcome that constraint, especially given the multi-hop non-geographic chained-request method in use (like TOR) which can drastically increase the latency of the network. There's [a good analysis and discussion of this bottleneck](https://safenetforum.org/t/hardware-network-communications-speeds-lags-bottlenecks/6021) on the safe network forum.
+The most obvious one, which was a complaint of similar systems such as freenet, will be bandwidth and latency. If the network cannot achieve efficiency in delivering and storing data, it will not be popular. There are strict physical limits to the speed at which a global network can operate, light simply won't travel through fibre optic any faster. Safe will need to overcome that constraint, especially given the multi-hop non-geographic chained-request method in use (like TOR) which can drastically increase the latency of the network. There's [a good analysis and discussion of this bottleneck](https://safenetforum.org/t/hardware-network-communications-speeds-lags-bottlenecks/6021) on the SAFE Network forum.
 
 One of the ways this is resolved is called opportunistic caching. The idea is that popular data is cached close to the source requesting it, so any future requests can be served much more rapidly. Caching is well known to be an extremely prickly subject, one that I'm not going to cover here; all I want is to bring awareness to this feature so if it's something you're interested in there's a stepping-off point to your search.
 
-Another issue around scaling for both networks is participation. In bitcoin this is the problem of having enough 'full nodes'. In the safe network this will probably be problem of having enough 'vaults' (although slightly different since a vault is like both bitcoins full nodes and a miners). How do you ensure that people participate and how do you keep them involved once they begin?
+Another issue around scaling for both networks is participation. In bitcoin this is the problem of having enough 'full nodes'. In the SAFE Network this will probably be problem of having enough 'vaults' (although slightly different since a vault is like both bitcoins full nodes and a miners). How do you ensure that people participate and how do you keep them involved once they begin?
 
 There is no simple answer to this. A few points can be posited, but ultimately participation behavior can only be observed once the network is running. One advantage of safe is that to become a vault requires no overhead; simply download and start the software. Becoming a full node in bitcoin requires downloading the entire blockchain before the node can be a meaningful member of the network. True, there is some overhead to becoming a vault in that it's required to gain some level of authority from the network, but this is extremely lightweight and essentially zero cost, especially compared to downloading the blockchain.
 
-Blocks on the blockchain are 'getting full', which is obviously a scaling problem, perhaps the result of poor capacity planning (I'm inclined to say bitcoin has good capacity planning but the plan is badly communicated!). Does the safe network suffer from 'getting full'? It may. If there aren't enough vaults, or there's too much demand to store data, it may become very expensive to add more data. If that's the case, the additional reward should create the incentive to add more capacity, and the supply and demand should balance. The big difference with bitcoin is that bitcoin blocks can fill up due to a _rule_ of the network, whereas safe vaults can fill up due to _participation_ in the network. Safe can expand capacity by adding participants rather than changing the rules - adding participants is much easier than changing the rules. Safe should be much more elegant at handling capacity issues; we'll have to wait and see once the network launches.
+Blocks on the blockchain are 'getting full', which is obviously a scaling problem, perhaps the result of poor capacity planning (I'm inclined to say bitcoin has good capacity planning but the plan is badly communicated!). Does the SAFE Network suffer from 'getting full'? It may. If there aren't enough vaults, or there's too much demand to store data, it may become very expensive to add more data. If that's the case, the additional reward should create the incentive to add more capacity, and the supply and demand should balance. The big difference with bitcoin is that bitcoin blocks can fill up due to a _rule_ of the network, whereas safe vaults can fill up due to _participation_ in the network. Safe can expand capacity by adding participants rather than changing the rules - adding participants is much easier than changing the rules. Safe should be much more elegant at handling capacity issues; we'll have to wait and see once the network launches.
 
 [Back to Table Of Contents](#scaling_toc)
 
@@ -546,7 +546,7 @@ Blocks on the blockchain are 'getting full', which is obviously a scaling proble
 
 The true beauty and art of bitcoin is in successfully encoding incentives into a technological set of rules. Being a good participant of the bitcoin network always yields more reward than being a bad participant. Behaving 'selfishly' in bitcoin results in benefiting others at the same time. It's honestly amazing.
 
-What are the incentives of the safe network and will it succeed in fending off uncontrollable growth of bad actors the way bitcoin has?
+What are the incentives of the SAFE Network and will it succeed in fending off uncontrollable growth of bad actors the way bitcoin has?
 
 The mechanism of coin issuance is crucial to both networks.
 
@@ -570,7 +570,7 @@ However, the voting mechanism in bitcoin no longer represents the 'democratic' i
 
 One of the interesting developments was how 'votes' were cast to show support for Bitcoin XT and Bitcoin Classic. Full nodes would include the preference in their user agent, thus allowing a full node to indicate their preference without having to mine a block. This naturally led to people starting lots of full nodes to try to sway the perception of popularity. This is a classic sybil attack - one person pretending to be many. Since the vote miners include in blocks is the only one that matters, this tactic was unsuccessful in creating change on the bitcoin network (as should be expected).
 
-How does voting work on the safe network and can it be attacked with sybil attacks?
+How does voting work on the SAFE Network and can it be attacked with sybil attacks?
 
 There are two parts to this. The overall network consensus rules (such as how coins are named, or how vaults are named), and the consensus rules to retain the integrity of each individual piece of data.
 
@@ -584,7 +584,7 @@ Can the individual data be attacked by sybil attacks?
 
 Yes it can, but again, it's extremely hard. The comparable 'ideal' to bitcoin voting is 'one vault one vote'. There is very little cost to starting a vault, so there's nothing to stop someone creating thousands or millions of malicious vaults and controlling the consensus mechanism that way. The issue is, they have no way to control the closeness of their nodes, so it's very difficult for them to form a close group consensus, especially if one or more people are simultaneously attempting a sybil attack, or there's significant healthy participation in the network. It also comes back to incentives - even if they could, why would they want to? They'd get more reward for utilizing the vaults as a resource than they would using them to perform malicious actions.
 
-It's worth reading more about attacks to the safe network, since this is a complex topic and one that by my own confession isn't covered in adequate detail here. Check the [attacks on the safe network](https://safenetwork.wiki/en/FAQ#Attacks_on_the_SAFE_Network) section of the wiki for some additional info.
+It's worth reading more about attacks to the SAFE Network, since this is a complex topic and one that by my own confession isn't covered in adequate detail here. Check the [attacks on the SAFE Network](https://safenetwork.wiki/en/FAQ#Attacks_on_the_SAFE_Network) section of the wiki for some additional info.
 
 It's also worth reading about [Node Ageing](https://github.com/maidsafe/rfcs/blob/master/text/0045-node-ageing/0045-node-ageing.md), which affects the difficulty of joining the network and exerting authority over data.
 
@@ -652,15 +652,15 @@ An interesting point on this is that unlike bitcoin which must have the transact
 
 There really is so much to say about the genesis block. Encoding political messages into it, bootstrapping the network from it, quirks like being unable to spend it - the genesis block is a little world unto itself.
 
-All this detail can lead us into some interesting areas of the safe network.
+All this detail can lead us into some interesting areas of the SAFE Network.
 
-Encoded political messages. Perhaps the most significant part of this in relation to safe is the nature of public vs private data on the safe network.
+Encoded political messages. Perhaps the most significant part of this in relation to safe is the nature of public vs private data on the SAFE Network.
 
-The safe network can function as a single epic server for static web content. With built in DNS. And SSL. It's basically a new version of the internet, replacing layers 3-7 of the OSI network model. How does it do this? The thing to research is public data vs private data on the safe network. Also consider, much of the web these days is dynamic, not static. There's already existing solutions to dynamic content on the safe network, well worth checking out how it works.
+The SAFE Network can function as a single epic server for static web content. With built in DNS. And SSL. It's basically a new version of the internet, replacing layers 3-7 of the OSI network model. How does it do this? The thing to research is public data vs private data on the SAFE Network. Also consider, much of the web these days is dynamic, not static. There's already existing solutions to dynamic content on the SAFE Network, well worth checking out how it works.
 
 Bootstrapping the network. A concern for peer to peer networks is how to initially find other peers. This introduces a single point of failure and control. Bitcoin used IRC, safe uses either the last known set of nodes it connected to, or falls back to a hardcoded list.
 
-Quirks of the genesis block. Are there any quirks to starting the safe network? Not especially. There's no time-factor in the safe network, so the idea of genesis is far less relevant. This is also true of not having blocks; sequential ordering doesn't matter in the safe network, despite being a critical component in the operation of bitcoin and the blockchain.
+Quirks of the genesis block. Are there any quirks to starting the SAFE Network? Not especially. There's no time-factor in the SAFE Network, so the idea of genesis is far less relevant. This is also true of not having blocks; sequential ordering doesn't matter in the SAFE Network, despite being a critical component in the operation of bitcoin and the blockchain.
 
 There is one quirk: consider that 'safecoin can only be mined by storing data' but 'storing data requires safecoin'. How can this chicken and egg problem be solved? There's a proposal which can be read in the section titled [bootstrap with clients](https://github.com/maidsafe/rfcs/blob/cd47937ebf053e90bde20f18eced2866854e8234/text/0012-safecoin-implementation/0012-safecoin-implementation.md#bootstrap-with-clients) in the safecoin implementation rfc.
 
@@ -680,7 +680,7 @@ The only honest answer is, we don't know. It's a reasonable assumption that safe
 
 Bitcoin has a testnet which allows for experimentation and real world testing on non-production environments.
 
-How is the safe network tested through all the different phases of the software lifecycle?
+How is the SAFE Network tested through all the different phases of the software lifecycle?
 
 This is tough to answer without a fully developed network, but there are some early indicators.
 
@@ -688,9 +688,9 @@ The source code has unit tests.
 
 There are test networks currently operating on closed networks under the control of the maidsafe organization. This was recently opened up temporarily to public users, and more tests involving the public will continue into the future. Data on these test networks is frequently wiped so they aren't considered useful for public consumption at this stage.
 
-Savvy users may be able to set up their own isolated safe network, but it's not documented how to do this and is not considered a reasonable undertaking at this point in time.
+Savvy users may be able to set up their own isolated SAFE Network, but it's not documented how to do this and is not considered a reasonable undertaking at this point in time.
 
-I imagine in the future there will be a complementary testnet like with bitcoin, including a valueless test safecoin token. We'll have to wait and see what happens with the development, and this is certainly one area of the safe network which would benefit from additional contributions.
+I imagine in the future there will be a complementary testnet like with bitcoin, including a valueless test safecoin token. We'll have to wait and see what happens with the development, and this is certainly one area of the SAFE Network which would benefit from additional contributions.
 
 Bitcoin has 'bitcoin in a box' which allows users to run private instances of their own bitcoin network for testing and developing. This will almost certainly be a feature incorporated into the safe toolkit.
 
@@ -702,11 +702,11 @@ Testing churn, quorum sizes, latency etc will be extremely important to assessin
 
 Satoshi is infamous for his genius and his anonymity.
 
-Who are the key people behind the safe network?
+Who are the key people behind the SAFE Network?
 
 The story is not as romantic but the people are just as brilliant! David Irvine is the main front of the project, and has been involved since the inception of the project back in 2006. He's currently very active developing, designing, documenting, and in the safe community.
 
-Like bitcoin, there are prominent developers and community members working on safe. It's best to get involved in the community to gain a sense of who these people are. Overall, because of the modest amount of attention safe has received, the people do not tend to have the kind of cult-of-personality that people like Greg Maxwell, Peter Todd, Gavin Andresen, Andreas Antonopolous, etc have in the bitcoin community. This is healthy in some ways, but will be interesting to see how it evolves if the safe network gains significant traction.
+Like bitcoin, there are prominent developers and community members working on safe. It's best to get involved in the community to gain a sense of who these people are. Overall, because of the modest amount of attention safe has received, the people do not tend to have the kind of cult-of-personality that people like Greg Maxwell, Peter Todd, Gavin Andresen, Andreas Antonopolous, etc have in the bitcoin community. This is healthy in some ways, but will be interesting to see how it evolves if the SAFE Network gains significant traction.
 
 [Back to Table Of Contents](#satoshi-nakamoto_toc)
 
@@ -714,7 +714,7 @@ Like bitcoin, there are prominent developers and community members working on sa
 
 A phrase loved by bitcoin nerds, especially because it has a z in it so it sounds really cool, is the byzantine generals problem.
 
-I know the question is burning in your mind: how does the safe network solve the byzantine generals problem? It was burning in mine, and here is what you need to know.
+I know the question is burning in your mind: how does the SAFE Network solve the byzantine generals problem? It was burning in mine, and here is what you need to know.
 
 The byzantine generals problem occurs when nodes receive conflicting information and must resolve between themselves which is the correct information.
 
@@ -722,7 +722,7 @@ Bitcoin solves this by proof of work - whichever chain of proofs is the longest 
 
 Safe solves this using a combination of techniques: close group consensus, proof of resource, and vault ranking.
 
-"Close group consensus". It's been mentioned over and over and is the most important aspect to understanding the safe network.
+"Close group consensus". It's been mentioned over and over and is the most important aspect to understanding the SAFE Network.
 
 Data can only enter the network if it has achieved close group consensus. This means that even as the network changes due to vaults joining and leaving, there can be confidence that data integrity will be retained because the data has been verified and stored in a particular manner. Without close group consensus, data would not be stored in this special way, and may be vulnerable to corruption due to future network changes.
 
@@ -740,15 +740,15 @@ Trust me on this, read about those topics; if you like dropping a bit of byzanti
 
 Bitcoin wallets are not inherent to the bitcoin network or blockchains. Wallets are a third-party piece of software that keep track of what money you have and when and where you spent it. The blockchain makes it relatively easy (if not subtly challenging) to create bitcoin wallet apps, and many different wallets exist to suit a wide variety of needs.
 
-How does a user keep track of their safecoins on the safe network?
+How does a user keep track of their safecoins on the SAFE Network?
 
-This is an interesting question, because of the inherently different representation of coins on the bitcoin and safe network. There are built in tracking mechanisms in the safe network, read about them on the [safecoin management](https://github.com/maidsafe/rfcs/blob/cd47937ebf053e90bde20f18eced2866854e8234/text/0012-safecoin-implementation/0012-safecoin-implementation.md#safecoin-management) section of the safecoin implementation rfc.
+This is an interesting question, because of the inherently different representation of coins on the bitcoin and SAFE Network. There are built in tracking mechanisms in the SAFE Network, read about them on the [safecoin management](https://github.com/maidsafe/rfcs/blob/cd47937ebf053e90bde20f18eced2866854e8234/text/0012-safecoin-implementation/0012-safecoin-implementation.md#safecoin-management) section of the safecoin implementation rfc.
 
 But let's do a somewhat ludicrous thought experiment in the meantime.
 
 Bitcoin wallets look at every transaction ever made and find the ones that are useful to it and combine them all into a tracking mechanism called a wallet. Ludicrous!
 
-The equivalent on the safe network (if a tracking mechanism were not already built in) would involve looking at every individual safecoin (all 4.3B of them), and seeing which ones belong to me. Also ludicrous!
+The equivalent on the SAFE Network (if a tracking mechanism were not already built in) would involve looking at every individual safecoin (all 4.3B of them), and seeing which ones belong to me. Also ludicrous!
 
 Which one sounds crazier? I don't know myself! Let's wait until there's an official implementation of the network and safecoin and wallets, and in the meantime read whatever documentation may be available.
 
@@ -764,7 +764,7 @@ Another issue is, how does a wallet know when it has received new coins? Unless 
 
 Bitcoin transactions are actually tiny programs. They're verified by executing the program and checking the output is valid. This goes against the intuitive notion of a transaction as a simple 'signature checking' mechanism. Multisig is a good example of the power of the bitcoin transaction scripting language. The language opens powerful control mechanisms for data flow on the network. Platforms like ethereum take it a step further again, offering fully turing complete smart contracts.
 
-How does safe network handle complex permissions for the movement of data on the safe network?
+How does SAFE Network handle complex permissions for the movement of data on the SAFE Network?
 
 This is another two-parter. Immutable data does not move, so we'll ignore that here. The second part is mutable data.
 
@@ -784,13 +784,13 @@ As discussed in the multisig section, smart contracts are a hot topic in the wor
 
 Does safe support smart contracts?
 
-Yes and no. The mutable data component which is responsible for safecoins does not support smart contracts as we know them. It may in the future, but not the foreseeable future. One of the big decisions facing smart contracts is whether to make them turing complete, and if so, how to manage the incentive structure and costs around looping logic. All this is for the future, but the underlying safe network seems incredibly strong, and that strength starts with mutable data.
+Yes and no. The mutable data component which is responsible for safecoins does not support smart contracts as we know them. It may in the future, but not the foreseeable future. One of the big decisions facing smart contracts is whether to make them turing complete, and if so, how to manage the incentive structure and costs around looping logic. All this is for the future, but the underlying SAFE Network seems incredibly strong, and that strength starts with mutable data.
 
 It's also possible that other mutable data tokens besides safecoin may implement smart contracts, we can only know once the network is live and apps are being developed using the network.
 
-Due to the efficiency of the safe network and the design around proof-of-resource instead of proof-of-work or proof-of-stake, it seems quite natural that smart contracts will live on this network, incentivising the consumption of computation resource along side the current design of storage and bandwidth resource.
+Due to the efficiency of the SAFE Network and the design around proof-of-resource instead of proof-of-work or proof-of-stake, it seems quite natural that smart contracts will live on this network, incentivising the consumption of computation resource along side the current design of storage and bandwidth resource.
 
-There may be other ways to implement smart contracts on the safe network other than utilizing safecoin. If you can think of any please add to the discussion using the link at the very bottom of all of this.
+There may be other ways to implement smart contracts on the SAFE Network other than utilizing safecoin. If you can think of any please add to the discussion using the link at the very bottom of all of this.
 
 A good place to start reading more is the blog post [Beyond a copy of the Internet](https://metaquestions.me/2017/09/06/connecting-ideas-and-providing-much-needed-solutions/) by David Irvine.
 
@@ -800,13 +800,13 @@ A good place to start reading more is the blog post [Beyond a copy of the Intern
 
 One of the little used and sideshow benefits of bitcoin is the built in ability to sign and verify messages cryptographically.
 
-The safe network operates on the same asymmetric public/private key cryptography as bitcoin, and can also perform message signing and verification.
+The SAFE Network operates on the same asymmetric public/private key cryptography as bitcoin, and can also perform message signing and verification.
 
-To take this a step further and ask whether the safe network has any other little sideshows up its sleeve is a good question, but difficult to answer.
+To take this a step further and ask whether the SAFE Network has any other little sideshows up its sleeve is a good question, but difficult to answer.
 
-Where does the differentiation lie between a legitimate application and a sideshow advantage? Because of the extremely general nature of the safe network as a data storage platform, much more general than the bitcoin blockchain, it's more difficult to differentiate between 'sideshows' vs 'trivial applications'. Perhaps the difference isn't even important anyway.
+Where does the differentiation lie between a legitimate application and a sideshow advantage? Because of the extremely general nature of the SAFE Network as a data storage platform, much more general than the bitcoin blockchain, it's more difficult to differentiate between 'sideshows' vs 'trivial applications'. Perhaps the difference isn't even important anyway.
 
-No other sideshows of the safe network come to mind in the bitcoin sense of a sideshow, but there may be some out there which creative community members will bring to light.
+No other sideshows of the SAFE Network come to mind in the bitcoin sense of a sideshow, but there may be some out there which creative community members will bring to light.
 
 [Back to Table Of Contents](#signed-messages_toc)
 
@@ -814,11 +814,11 @@ No other sideshows of the safe network come to mind in the bitcoin sense of a si
 
 Bitcoin is trustless. Perfectly, purely, beautifully trustless. This means that transfers can happen in a network where the members may be malicious.
 
-The safe network is also trustless.
+The SAFE Network is also trustless.
 
-Since both the bitcoin and the safe network are decentralized, they're trustless in the sense that there's no single point of failure or authority or control. You don't have to trust anyone. You yourself can join the network any time and leave any time, no lockin, no contract, no bans, no trust.
+Since both the bitcoin and the SAFE Network are decentralized, they're trustless in the sense that there's no single point of failure or authority or control. You don't have to trust anyone. You yourself can join the network any time and leave any time, no lockin, no contract, no bans, no trust.
 
-There is some component to trustlessness on the safe network which differs to bitcoin. Proof of work is what makes bitcoin trustless, and the degree of security it offers is well studied and understood over a wide variety of network conditions. Close group consensus has undergone some scrutiny of the security it provides, which appears comparable to the security of proof of work. But I feel the security of close group consensus hasn't been clearly demonstrated yet. It's possible to do analysis of the security of close group consensus, to come up with probabilities and costs to break that security under various network conditions, but I have yet to see the results of such an analysis. If you know of one, please post it to the discussion using the link at the very bottom of all this.
+There is some component to trustlessness on the SAFE Network which differs to bitcoin. Proof of work is what makes bitcoin trustless, and the degree of security it offers is well studied and understood over a wide variety of network conditions. Close group consensus has undergone some scrutiny of the security it provides, which appears comparable to the security of proof of work. But I feel the security of close group consensus hasn't been clearly demonstrated yet. It's possible to do analysis of the security of close group consensus, to come up with probabilities and costs to break that security under various network conditions, but I have yet to see the results of such an analysis. If you know of one, please post it to the discussion using the link at the very bottom of all this.
 
 [Back to Table Of Contents](#trustlessness_toc)
 
@@ -826,7 +826,7 @@ There is some component to trustlessness on the safe network which differs to bi
 
 The mantra to safely using bitcoin is 'cold storage'. All the exchanges have it, individuals are compelled, hackers hate it.
 
-What degrees of security can be applied to the safe network?
+What degrees of security can be applied to the SAFE Network?
 
 There are a few parts to this.
 
@@ -836,15 +836,15 @@ Secondly, security of account details for the network. These allow you to access
 
 Unlocking your account requires two pieces of data. A secret and a password. There's been a lot of discussion about why this [curious login mechanism](https://safenetforum.org/t/discussion-about-the-password-requirements-in-safe-launcher/10497) is used instead of the username password paradigm we're all familiar with. It's something you could be explaining to new users _a lot_.
 
-There's one particularly good aspect to the login mechanism: convenience. This one login is used as a seed to derive a unique login for every app that uses the safe network. This (to me anyway) is amazing. Reuse of passwords will be a thing of the past. Short and insecure passwords, also in the past. This style of login and identity management has been a long time in the making, hopefully the safe network popularizes it and it works as expected. We can only know by seeing how users use it. There's a lot more detail in the [new auth flow](https://github.com/maidsafe/rfcs/blob/c63ff6636d0dc21d6939856cf3a32445c3855b8c/text/0046-new-auth-flow/0046-new-auth-flow.md) rfc.
+There's one particularly good aspect to the login mechanism: convenience. This one login is used as a seed to derive a unique login for every app that uses the SAFE Network. This (to me anyway) is amazing. Reuse of passwords will be a thing of the past. Short and insecure passwords, also in the past. This style of login and identity management has been a long time in the making, hopefully the SAFE Network popularizes it and it works as expected. We can only know by seeing how users use it. There's a lot more detail in the [new auth flow](https://github.com/maidsafe/rfcs/blob/c63ff6636d0dc21d6939856cf3a32445c3855b8c/text/0046-new-auth-flow/0046-new-auth-flow.md) rfc.
 
 It raises a good question though - why do I need an account, where are my login credentials stored and how do I change them?
 
 You only need an account if you want to store your data on the network. To view data does not require an account.
 
-Account credentials aren't really _stored_ anywhere. They're kept in RAM at login and retained in RAM until the user logs out or closes the application. When the safe network connection is closed, the credentials are freed from memory. Any data saved to the network is encrypted using these credentials and can only be retrieved by using those same credentials. This has got me thinking of a 'remember me' feature, it seems inevitable. Could be really handy - one strong password to decrypt the trilogy of information to log in (the trilogy can also be long values since they don't need to be remembered). I'm sure there will be lots of innovation on the client side.
+Account credentials aren't really _stored_ anywhere. They're kept in RAM at login and retained in RAM until the user logs out or closes the application. When the SAFE Network connection is closed, the credentials are freed from memory. Any data saved to the network is encrypted using these credentials and can only be retrieved by using those same credentials. This has got me thinking of a 'remember me' feature, it seems inevitable. Could be really handy - one strong password to decrypt the trilogy of information to log in (the trilogy can also be long values since they don't need to be remembered). I'm sure there will be lots of innovation on the client side.
 
-This means 'there are no accounts on the safe network, just data'. To extend that logic, it's not possible to brute force an account in the traditional sense of 'obtain a copy of the encrypted or hashed account details and brute force them to plaintext'. It _is_ possible to simply guess account details over and over, but every account guess will lead to the creation of a legitimate (but probably empty) account on the safe network. If you guess a non-empty account, huzzah, but chances of that should be low. So this is a bit of a stalemate for security I feel. On one hand, application logins are simplified and more secure, on the other, they're still vulnerable to poor user selection of client credentials.
+This means 'there are no accounts on the SAFE Network, just data'. To extend that logic, it's not possible to brute force an account in the traditional sense of 'obtain a copy of the encrypted or hashed account details and brute force them to plaintext'. It _is_ possible to simply guess account details over and over, but every account guess will lead to the creation of a legitimate (but probably empty) account on the SAFE Network. If you guess a non-empty account, huzzah, but chances of that should be low. So this is a bit of a stalemate for security I feel. On one hand, application logins are simplified and more secure, on the other, they're still vulnerable to poor user selection of client credentials.
 
 The question remains, how does a user change their account details like their password?
 
@@ -858,13 +858,13 @@ Read more about the client and app authentication and authorization in the [new 
 
 The bitcoin community is well known for being extremely enthusiastic, with many other less desirable adjectives equally applicable.
 
-What's the safe community like and what issues has it presented for the progress of the safe network project?
+What's the safe community like and what issues has it presented for the progress of the SAFE Network project?
 
 This is something you're best to judge for yourself.
 
 * [Forum](https://safenetforum.org/) is the main place to commune.
 * [Reddit for maidsafe](https://www.reddit.com/r/maidsafe) is the bigger reddit community.
-* [Reddit for safe network](https://www.reddit.com/r/safenetwork) is the smaller reddit community.
+* [Reddit for SAFE Network](https://www.reddit.com/r/safenetwork) is the smaller reddit community.
 
 I've found the community to be extremely welcoming and friendly, although there are of course a few bristly interactions and misunderstandings. The moderators and team of experts seem friendly and highly engaged. It's clearly still early days for the community, and it's generally a pretty nice place to be.
 
@@ -892,9 +892,9 @@ BIPs are amazing and I regularly refer to them. The same is true of safe RFCs, s
 
 The bitcoin whitepaper is a well respected document for it's concise yet fairly complete description of the bitcoin network.
 
-The safe network whitepaper is, shall we say, underwhelming and contains outdated or irrelevant information. You can read it [here](https://github.com/maidsafe/Whitepapers/blob/63af19e3e39d60a43cb722e32270fab40213abf1/Project-Safe.md). This is a link to the first version of the whitepaper, it has a more recent copy in the repository history.
+The SAFE Network whitepaper is, shall we say, underwhelming and contains outdated or irrelevant information. You can read it [here](https://github.com/maidsafe/Whitepapers/blob/63af19e3e39d60a43cb722e32270fab40213abf1/Project-Safe.md). This is a link to the first version of the whitepaper, it has a more recent copy in the repository history.
 
-This illustrates a more general issue with the safe network documentation - it's fragmented and spread over many years and formats, which makes it challenging to find out more about the network. I'm aware this very document itself is going to contribute slightly to that problem. There's a plan to fix the overall state of maidsafe documentation, but (ironically) I can't find where that's stated. In the meantime, have a look at [the roadmap](http://maidsafe.net/roadmap) for the project; it seems pretty interesting and gives some good hooks into what topics to research if you want to learn more about the network.
+This illustrates a more general issue with the SAFE Network documentation - it's fragmented and spread over many years and formats, which makes it challenging to find out more about the network. I'm aware this very document itself is going to contribute slightly to that problem. There's a plan to fix the overall state of maidsafe documentation, but (ironically) I can't find where that's stated. In the meantime, have a look at [the roadmap](http://maidsafe.net/roadmap) for the project; it seems pretty interesting and gives some good hooks into what topics to research if you want to learn more about the network.
 
 [Back to Table Of Contents](#whitepape_toc)
 
@@ -902,13 +902,13 @@ This illustrates a more general issue with the safe network documentation - it's
 
 One of the reasons bitcoin is so strong is it was first. People want to be involved in a project that is likely to succeed, and bitcoin has shown the greatest success so far. The ability of bitcoin to incorporate new innovations from altcoins makes it extremely difficult to replace now that it's established as the leader.
 
-Can the safe network overcome this?
+Can the SAFE Network overcome this?
 
 Another speculative section, but let's look at the possible reasons safe may rise in popularity.
 
-The fundamental difference of not using a blockchain may lead people to prefer the safe network if it can prove itself more efficient for users. It may be that users understand there's basically no difference between 'data' on the safe network and 'money' on the bitcoin network, and they may decide to use the more efficient system.
+The fundamental difference of not using a blockchain may lead people to prefer the SAFE Network if it can prove itself more efficient for users. It may be that users understand there's basically no difference between 'data' on the SAFE Network and 'money' on the bitcoin network, and they may decide to use the more efficient system.
 
-Safe has flown under the radar despite the impressive technical accomplishments, and will probably continue to do so until the network is live and can prove how well it achieves the goals (or not). In contrast, popular perception of bitcoin is being hijacked by the notion of 'the blockchain, not bitcoin', which may preface another interesting dynamic in the reception of the safe network once it gains more attention.
+Safe has flown under the radar despite the impressive technical accomplishments, and will probably continue to do so until the network is live and can prove how well it achieves the goals (or not). In contrast, popular perception of bitcoin is being hijacked by the notion of 'the blockchain, not bitcoin', which may preface another interesting dynamic in the reception of the SAFE Network once it gains more attention.
 
 I personally think the transaction mechanism of safecoin is superior to bitcoin, and think it will eventually displace bitcoin for _transfers_ of wealth. Whether safecoin can capture the _storage_ of wealth component of bitcoin is totally uncertain. The monetary policy behaves similarly to bitcoin, so there is some chance it may be used as a general store of value.
 
@@ -922,11 +922,11 @@ There will be no shortage of opinions about this topic. Feel free to add your th
 
 There's a lot of lingo in bitcoin; if you've ever listened to nerds talking about it you'll know what I mean. It sounds like a foreign language.
 
-How does a hardcore safe network conversation sound? Would a bitcoiner be able to follow it?
+How does a hardcore SAFE Network conversation sound? Would a bitcoiner be able to follow it?
 
-By far the most important term to understand is close group consensus. This is the 'blockchain equivalent term' which makes the safe network possible.
+By far the most important term to understand is close group consensus. This is the 'blockchain equivalent term' which makes the SAFE Network possible.
 
-Here's some of the essential phrases and words for taking part in a technical conversation about safe network:
+Here's some of the essential phrases and words for taking part in a technical conversation about SAFE Network:
 
 * churn
 * close group consensus
@@ -934,7 +934,7 @@ Here's some of the essential phrases and words for taking part in a technical co
 * [data chains](https://metaquestions.me/2016/07/20/data-chains-what-why-how/) - also see [the RFC](https://github.com/maidsafe/rfcs/blob/master/text/0029-data-chains.md/0029-data-chains.md)
 * distributed hash table (DHT), especially the kademlia implementation
 * farming
-* k-buckets, especially the [unique implementation](https://github.com/maidsafe/rfcs/blob/1cd4ed22709fed673f5ce51c1d861d879abd7aec/text/0019-new-kademlia-routing-logic/0019-new-kademlia-routing-logic.md) in the safe network
+* k-buckets, especially the [unique implementation](https://github.com/maidsafe/rfcs/blob/1cd4ed22709fed673f5ce51c1d861d879abd7aec/text/0019-new-kademlia-routing-logic/0019-new-kademlia-routing-logic.md) in the SAFE Network
 * network addressable element
 * node ageing, see [the RFC](https://github.com/maidsafe/rfcs/blob/master/text/0045-node-ageing/0045-node-ageing.md)
 * opportunistic caching
@@ -949,7 +949,7 @@ Here's some of the essential phrases and words for taking part in a technical co
 There's also some interesting comments from prominent figures in the bitcoin and blockchain community:
 
 * [Vitalik Buterin comments](https://safenetforum.org/t/vitalik-buterin-on-maidsafes-consensus-mechanism/3542) on the consensus mechanism - a great read.
-* [Andreas Antonopolous](https://safenetforum.org/t/andreas-antonopoulos-gives-thoughts-on-the-safe-network/8662) comments on his interpretation of the safe network.
+* [Andreas Antonopolous](https://safenetforum.org/t/andreas-antonopoulos-gives-thoughts-on-the-safe-network/8662) comments on his interpretation of the SAFE Network.
 
 If you know of any other comments that would help bridge the gap between bitcoin and safe, please let me know using the link at the bottom of all this.
 
@@ -957,14 +957,14 @@ If you know of any other comments that would help bridge the gap between bitcoin
 
 ## More
 
-It's one thing to look at safe network from the perspective of a bitcoiner, but to really appreciate safe it's necessary to step away from the nomenclature of bitcoin and read about the network as a standalone project. Not every aspect of the safe network has been covered here, there are other aspects that are unique to safe and are difficult to discuss from a bitcoin-centric perspective.
+It's one thing to look at SAFE Network from the perspective of a bitcoiner, but to really appreciate safe it's necessary to step away from the nomenclature of bitcoin and read about the network as a standalone project. Not every aspect of the SAFE Network has been covered here, there are other aspects that are unique to safe and are difficult to discuss from a bitcoin-centric perspective.
 
-To properly understand the safe network, the following resources are good places to start:
+To properly understand the SAFE Network, the following resources are good places to start:
 
 * [Source code](https://github.com/maidsafe)
 * [Wiki](https://safenetwork.wiki/en/Main_Page)
 * [Forum](https://safenetforum.org/)
-* [Book](http://systemdocs.maidsafe.net/content/en/)
+* [Primer](https://maidsafe.net/#safePrimer)
 * [Website](http://maidsafe.net/)
 * [Blog](https://blog.maidsafe.net/)
 

--- a/_posts/2017-09-07-architecture.markdown
+++ b/_posts/2017-09-07-architecture.markdown
@@ -12,15 +12,15 @@ categories: architecture
 
 ## Summary
 
-The SAFE network is an autonomous distributed network for data storage and communications [1]. It provides Secure Access For Everyone (SAFE). Data stored on the network has extremely high availability, durability, privacy and security. The network scales efficiently and the security of data stored on the network increases as the network grows.
+The SAFE Network is an autonomous distributed network for data storage and communications [1]. It provides Secure Access For Everyone (SAFE). Data stored on the network has extremely high availability, durability, privacy and security. The network scales efficiently and the security of data stored on the network increases as the network grows.
 
 ## Introduction
 
-The existing server-client-based internet gives ownership of data to whoever operates the servers, rather than the people creating the data. The operators can restrict, modify, remove or sell that data with no recourse from the user that created it. Poor acceptance and availability of federated protocols to distribute user data on terms that favour the creators has motivated the creation of the SAFE network.
+The existing server-client-based internet gives ownership of data to whoever operates the servers, rather than the people creating the data. The operators can restrict, modify, remove or sell that data with no recourse from the user that created it. Poor acceptance and availability of federated protocols to distribute user data on terms that favour the creators has motivated the creation of the SAFE Network.
 
-Clients storing data on the SAFE network are protected by default with strong encryption and can control access through a flexible permissions layer.
+Clients storing data on the SAFE Network are protected by default with strong encryption and can control access through a flexible permissions layer.
 
-Clients retrieving data from the SAFE network are protected by a secure routing and addressing system.
+Clients retrieving data from the SAFE Network are protected by a secure routing and addressing system.
 
 Clients benefit from secure defaults, including built-in end-to-end encryption and secure authentication.
 
@@ -30,25 +30,25 @@ Network tokens called Safecoin are distributed to vault operators by the network
 
 The network utilises SHA3-256 identifiers for vaults and data in combination with XOR distances between these identifiers to anonymise and globally distribute all data and traffic.
 
-Much of the existing internet infrastructure is improved by the SAFE network, including Addressing, Domain Name System, Transport Layer Security, Packet Routing, server software such as http web servers and imap mail servers, authentication layers such as oauth and openid; these are all superseded by secure-by-default modules that combine to make the SAFE network operable.
+Much of the existing internet infrastructure is improved by the SAFE Network, including Addressing, Domain Name System, Transport Layer Security, Packet Routing, server software such as http web servers and imap mail servers, authentication layers such as oauth and openid; these are all superseded by secure-by-default modules that combine to make the SAFE Network operable.
 
 SAFE operates on existing physical internet infrastructure, but replaces all layers of the network from there up. It primarily targets OSI layers 3 to 7.
 
 ## Client Operations
 
-Clients can upload and download data from the SAFE network. This section outlines how these operations are conducted.
+Clients can upload and download data from the SAFE Network. This section outlines how these operations are conducted.
 
 ### Resource Identifiers
 
-Clients that wish to download data from the SAFE network require software that can translate SAFE resource identifiers to enpoints on the SAFE network, much like how browsers translate http URLs to endpoints on a server. Downloading data requires no special permissions or access, just software that can locate and interpret the data on the network.
+Clients that wish to download data from the SAFE Network require software that can translate SAFE resource identifiers to enpoints on the SAFE Network, much like how browsers translate http URLs to endpoints on a server. Downloading data requires no special permissions or access, just software that can locate and interpret the data on the network.
 
 Resources are stored on the network as content addressable resources. The identifier for these resources are SHA3-256 hashes of the resource content. This 256 bit identifier is used to retrieve a resource from the network (thus acting similarly to an IP address), allowing the client to specify which part of the network may be able to serve their request.
 
-The 256 bit resource identifier may be represented in a human-friendly form using the built-in SAFE DNS, such as `safe://www.userX/video.mp4`. This can be converted to the 256 bit identifier for the file by a lookup on the SAFE network using software that can interpret SAFE DNS records.
+The 256 bit resource identifier may be represented in a human-friendly form using the built-in SAFE DNS, such as `safe://www.userX/video.mp4`. This can be converted to the 256 bit identifier for the file by a lookup on the SAFE Network using software that can interpret SAFE DNS records.
 
 ### Self Encryption
 
-Resources on the SAFE network are never more than 1 MB each. Clients working with files larger than 1 MB will have their data automatically split into 1 MB chunks that are then distributed across the network.
+Resources on the SAFE Network are never more than 1 MB each. Clients working with files larger than 1 MB will have their data automatically split into 1 MB chunks that are then distributed across the network.
 
 This means a typical file on the network consists of several parts: *chunks* which are individual 1 MB portions after the file is split, and a *datamap* which stores the identifier of each portion of the file. The network sees the datamap as just another chunk.
 
@@ -103,13 +103,13 @@ Nodes along the route can cache the chunk so if another request for it is made l
 
 ### Messaging
 
-Email and instant messaging are ubiquitous experiences of the current internet. The SAFE network facilitates messaging which can replace imap / smtp / xmpp servers.
+Email and instant messaging are ubiquitous experiences of the current internet. The SAFE Network facilitates messaging which can replace imap / smtp / xmpp servers.
 
-A message may be stored on the network the same way any resource may be stored. To ensure the message remains private, the message may be encrypted prior to sending using the recipients key (that key can also be stored as a resource on the safe network). By the same method, connections between contacts (like the gpg web of trust) may also be represented on the network by resources. This collection of resources form the foundation for a secure messaging platform.
+A message may be stored on the network the same way any resource may be stored. To ensure the message remains private, the message may be encrypted prior to sending using the recipients key (that key can also be stored as a resource on the SAFE Network). By the same method, connections between contacts (like the gpg web of trust) may also be represented on the network by resources. This collection of resources form the foundation for a secure messaging platform.
 
 The only remaining step is to notify the recipient when they have received a message.
 
-On the current internet, new messages are typically presented to the user by adding a message to their inbox. Since an inbox is simply a list of messages, this list may be represented as a resource on the network. However, in the case of the SAFE network, the inbox is created not as immutable data, but as mutable data. This second data type has a fixed identifier which does not depend on the content of the resource. This, combined with a permissions system, allows data at that identifier to be updated.
+On the current internet, new messages are typically presented to the user by adding a message to their inbox. Since an inbox is simply a list of messages, this list may be represented as a resource on the network. However, in the case of the SAFE Network, the inbox is created not as immutable data, but as mutable data. This second data type has a fixed identifier which does not depend on the content of the resource. This, combined with a permissions system, allows data at that identifier to be updated.
 
 This data type allows the recipient to be notified of their new message by updating the data located at the identifier for the recipients inbox. The inbox resource can be created with permission for anyone to append new data. The sender of the message appends the identifier of their message to the inbox of the recipient, and the recipient is able to locate the new message.
 
@@ -221,7 +221,7 @@ The network defines cooperative behaviour as the reliable supply of bandwidth an
 
 ## Conclusion
 
-The SAFE network is an autonomous network for reliable data storage and communications. The combination of a robust data storage and messaging system forms a secure and private alternative to much of the existing infrastructure of the internet.
+The SAFE Network is an autonomous network for reliable data storage and communications. The combination of a robust data storage and messaging system forms a secure and private alternative to much of the existing infrastructure of the internet.
 
 Data is stored efficiently and reliably on the network using content addressable resource identifiers and self encryption.
 
@@ -231,7 +231,7 @@ A network allocated token to incentivise the supply of resources within the agre
 
 The network improves in speed, security and reliability as more vaults are added, making rapid increases in scale a benefit rather than a concern.
 
-End users benefit from secure-by-default modules and a flexible permissions layer to control access in the manner best suit their needs. The SAFE network combines many individual modules to create a network with Secure Access For Everyone.
+End users benefit from secure-by-default modules and a flexible permissions layer to control access in the manner best suit their needs. The SAFE Network combines many individual modules to create a network with Secure Access For Everyone.
 
 ## References
 

--- a/_posts/2017-11-24-splits-and-merges.markdown
+++ b/_posts/2017-11-24-splits-and-merges.markdown
@@ -11,13 +11,13 @@ The code for splits and merges is quite difficult to interpret but I think I've 
 
 # Splitting and Merging Sections
 
-Splitting and merging sections on the safe network is an important and basic part of the network functionality. It determines which nodes are responsible for your data and how that responsibility changes over time. It's quite an elegant and fascinating mechanism and deserves some explanation.
+Splitting and merging sections on the SAFE Network is an important and basic part of the network functionality. It determines which nodes are responsible for your data and how that responsibility changes over time. It's quite an elegant and fascinating mechanism and deserves some explanation.
 
 ## Why Split And Merge
 
-The safe network consists of many vaults. 8 or more vaults can combine to form a cluster of nodes known as a 'section' which becomes responsible for any data allocated to it by the network.
+The SAFE Network consists of many vaults. 8 or more vaults can combine to form a cluster of nodes known as a 'section' which becomes responsible for any data allocated to it by the network.
 
-The structure of the section that form the safe network is constantly changing. New vaults will periodically join a section (making the section larger) and existing vaults periodically leave the section (making the section smaller).
+The structure of the section that form the SAFE Network is constantly changing. New vaults will periodically join a section (making the section larger) and existing vaults periodically leave the section (making the section smaller).
 
 Very large sections are detrimental to the network because they create a centralisation risk to the data they're responsible for.
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # About
 
-The safe network can be difficult to understand. These explanations aim to make it simple.
+The SAFE Network can be difficult to understand. These explanations aim to make it simple.
 
 View the site at [https://safe-network-explained.github.io](https://safe-network-explained.github.io).
 


### PR DESCRIPTION
I replaced all instances of "Safe Network", "safe network", etc. by "SAFE Network" (resolves #1).

I also replaced the link to the System Docs Book (which doesn't exist anymore) with a link to the new SAFE Network Primer.